### PR TITLE
Allow safe sql values to avoid dangerous query method error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Support plucking custom Arel columns
+
 ## 0.2.0 (2023-07-24)
 
 - Support specifying per cursor column ordering when batching

--- a/lib/pluck_in_batches/iterator.rb
+++ b/lib/pluck_in_batches/iterator.rb
@@ -35,7 +35,14 @@ module PluckInBatches
         raise ArgumentError, ":order must be :asc or :desc or an array consisting of :asc or :desc, got #{order.inspect}"
       end
 
-      pluck_columns = columns.map(&:to_s)
+      pluck_columns = columns.map do |column|
+        case column
+        when String, Arel::Nodes::SqlLiteral
+          column
+        else
+          column.to_s
+        end
+      end
       cursor_columns = Array(cursor_column).map(&:to_s)
       cursor_column_indexes = cursor_column_indexes(pluck_columns, cursor_columns)
       missing_cursor_columns = cursor_column_indexes.count(&:nil?)

--- a/lib/pluck_in_batches/iterator.rb
+++ b/lib/pluck_in_batches/iterator.rb
@@ -36,13 +36,13 @@ module PluckInBatches
       end
 
       pluck_columns = columns.map do |column|
-        case column
-        when String, Arel::Nodes::SqlLiteral
+        if Arel.arel_node?(column)
           column
         else
           column.to_s
         end
       end
+
       cursor_columns = Array(cursor_column).map(&:to_s)
       cursor_column_indexes = cursor_column_indexes(pluck_columns, cursor_columns)
       missing_cursor_columns = cursor_column_indexes.count(&:nil?)

--- a/test/pluck_in_batches_test.rb
+++ b/test/pluck_in_batches_test.rb
@@ -48,18 +48,13 @@ class PluckInBatchesTest < TestCase
     end
   end
 
-  def test_pluck_in_batches_should_return_batches_for_safe_sql_columns
-    ids, ranks = User.order(:id)
-                     .pluck(:id, Arel.sql("json_extract(users.metadata, '$.rank')"))
-                     .each_with_object([[], []]) do |(id, rank), (ids, ranks)|
-                       ids << id
-                       ranks << rank
-                     end
+  def test_pluck_in_batches_should_return_batches_for_arel_columns
+    ids_and_ranks = User.order(:id).pluck(:id, Arel.sql("json_extract(users.metadata, '$.rank')"))
+
     assert_queries(User.count + 1) do
       User.pluck_in_batches(:id, Arel.sql("json_extract(users.metadata, '$.rank')"), batch_size: 1).with_index do |batch, index|
         assert_kind_of Array, batch
-        assert_equal ids[index], batch.first[0]
-        assert_equal ranks[index], batch.first[1]
+        assert_equal ids_and_ranks[index], batch.first
       end
     end
   end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -3,6 +3,7 @@
 ActiveRecord::Schema.define do
   create_table :users, force: true do |t|
     t.string :name
+    t.json :metadata, null: false, default: {}
   end
 
   create_table :subscribers, id: false, primary_key: :nick, force: true do |t|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,9 +23,9 @@ def prepare_database
   # Create users
   values = 20.times.map do |i|
     id = i + 1
-    "(#{id}, 'User-#{id}')"
+    "(#{id}, 'User-#{id}', json('{\"rank\": #{i}}'))"
   end.join(", ")
-  ActiveRecord::Base.connection.execute("INSERT INTO users (id, name) VALUES #{values}")
+  ActiveRecord::Base.connection.execute("INSERT INTO users (id, name, metadata) VALUES #{values}")
 
   # Create subscribers
   values = 10.times.map do |i|


### PR DESCRIPTION
json columns require Arel.sql safe specified strings for querying. The mapping of provided columns to strings via `to_s` was overwriting this specification and so it will always raise an [ActiveRecord::UnknownAttributeReference](https://api.rubyonrails.org/classes/ActiveRecord/UnknownAttributeReference.html): Dangerous query method error

This honors given column strings/arel safe strings